### PR TITLE
Relay_Mode: change F101 instance ID from 1C to 1B to allow for discovery

### DIFF
--- a/MavlinkToPassthruPlus_v0.23/FrSkySPortPassthru.ino
+++ b/MavlinkToPassthruPlus_v0.23/FrSkySPortPassthru.ino
@@ -960,15 +960,15 @@ void SendRssiF101() {          // data id 0xF101 RSSI tell LUA script in Taranis
   else
     fr_rssi = 255;     // We may have a connection but don't yet know how strong. Prevents spurious "Telemetry lost" announcement
   #ifdef Frs_Dummy_rssi
-    fr_rssi = 87;
+    fr_rssi = 70;
     Debug.print(" Dummy rssi="); Debug.println(fr_rssi); 
   #endif
   bit32Pack(fr_rssi ,0, 32);
   
   #ifdef Relay_Mode
     FrSkySPort_SendByte(0x7E, false);   
-    FrSkySPort_SendByte(0x1C, false);  
-    FrSkySPort_SendDataFrame(0x1C, 0xF101,fr_payload); 
+    FrSkySPort_SendByte(0x1B, false);  
+    FrSkySPort_SendDataFrame(0x1B, 0xF101,fr_payload); 
   #else
     FrSkySPort_SendDataFrame(0x1B, 0xF101,fr_payload); 
   #endif

--- a/MavlinkToPassthru_v1.0.10/FrSkySPortPassthru.ino
+++ b/MavlinkToPassthru_v1.0.10/FrSkySPortPassthru.ino
@@ -780,8 +780,8 @@ void SendRssiF101() {          // data id 0xF101 RSSI tell LUA script in Taranis
   
   #ifdef Relay_Mode
     FrSkySPort_SendByte(0x7E, false);   
-    FrSkySPort_SendByte(0x1C, false);  
-    FrSkySPort_SendDataFrame(0x1C, 0xF101,fr_payload); 
+    FrSkySPort_SendByte(0x1B, false);  
+    FrSkySPort_SendDataFrame(0x1B, 0xF101,fr_payload); 
   #else
     FrSkySPort_SendDataFrame(0x1B, 0xF101,fr_payload); 
   #endif


### PR DESCRIPTION
Hi Eric,
I was helping a user getting my script to run with the teensy in relay mode and I could not get the MAVLINK RSSI to be discovered as sensor F101 but after changing the instance ID from 1C to 1B the sensor appeared as RSSI with ID = 28.
This way discovery reports 2 RSSI sources with the frsky one (ID 25) having priority over the teensy one (ID 28).
For having both the radio and my script use the teensy one (ID 28) the frsky one has to be deleted.