### PR TITLE
fix RPM and Terrain 0x500A and 0x500B (probbaly an issue with bit32pack)

### DIFF
--- a/stable/MavToPass/FrSky_Ports.h
+++ b/stable/MavToPass/FrSky_Ports.h
@@ -399,7 +399,7 @@
       }
 
       if (set.trmode == ground) {   
-          if(mavGood  && ((millis() - blind_inject_millis) > 18)) {  
+          if(mavGood  && ((millis() - blind_inject_millis) > 24)) {
             fr_prime = 0x10;
             FrSkyPort::InjectUplinkFrame(fr_prime);        // Blind inject frame into Taranis et al 
             blind_inject_millis=millis();
@@ -1434,7 +1434,7 @@
       uint8_t byte;
       byte = 0xFF-crcout;
 
-      FrSkyPort::SafeWrite(byte, false);
+      FrSkyPort::SafeWrite(byte, true);
 
       crcout = 0;          // crcout reset
     }
@@ -1465,7 +1465,6 @@
       switch(msg_id) {
 
         // MavLite below
-        
         case 0x16:                   // msg_id 0x16 MavLite PARAM_VALUE ( #22 )
           FrSkyPort::Push_Param_Val_016(msg_id);
           break; 
@@ -1475,7 +1474,6 @@
           break;           
 
         // Passthrough below
-        
         case 0x800:                  // msg_id 0x800 Lat & Lon
           if (sub_id == 0) {
             FrSkyPort::Push_Lat_800(msg_id);
@@ -2403,8 +2401,10 @@ if (ap24_sat_visible > 15) {                // @rotorman 2021/01/18
       pt_rpm1 = (int16_t)roundf(ap_rpm1 * 0.1);
       pt_rpm2 = (int16_t)roundf(ap_rpm2 * 0.1);
 
-      bit32Pack(pt_rpm1, 0, 16);
-      bit32Pack(pt_rpm2, 16, 16);
+      //bit32Pack(pt_rpm1, 0, 16);
+      //bit32Pack(pt_rpm2, 16, 16);
+      
+      pt_payload = pt_rpm1 | (pt_rpm2 << 16);
 
       FrSkyPort::PushToEmptyRow(msg_id, 1);
 
@@ -2425,8 +2425,10 @@ if (ap24_sat_visible > 15) {                // @rotorman 2021/01/18
       pt_height_above_terrain = prep_number(roundf(ap136_current_height*10), 3, 2);
       pt_terrain_unhealthy = ap_terrain_spacing == 0 ? 1 : 0;
 
-      bit32Pack(pt_height_above_terrain, 0, 13);
-      bit32Pack(pt_terrain_unhealthy, 13, 1);
+      //bit32Pack(pt_height_above_terrain, 0, 13);
+      //bit32Pack(pt_terrain_unhealthy, 13, 1);
+
+      pt_payload = pt_height_above_terrain | (pt_terrain_unhealthy << 13);
 
       FrSkyPort::PushToEmptyRow(msg_id, 1);
 

--- a/stable/MavToPass/MavToPass.ino
+++ b/stable/MavToPass/MavToPass.ino
@@ -255,7 +255,6 @@ void LogScreenPrint(String);
   void HandleDisplayButtons();  
 #endif
 
-
   #if (defined frBuiltin)
     FrSkyPort FrPort;   // instantiate FrSky Port object   
   #endif


### PR DESCRIPTION
added some more delay between sport frames from 18ms to 24ms to prevent
status text corruption due to high packet rate

this also fixes a CRC issue 