### PR TITLE
Only decode mavlink from the first connected autopilot

### DIFF
--- a/Source/New/MavToPass_v2.68.04/MavToPass/global_variables.h
+++ b/Source/New/MavToPass_v2.68.04/MavToPass/global_variables.h
@@ -146,6 +146,7 @@ uint8_t    mvType;
 
 // Message #0  HEARTHBEAT 
 uint8_t    ap_type_tmp = 0;              // hold the type until we know HB not from GCS or Tracker
+uint8_t    ap_autopilot_tmp = 0;
 uint8_t    ap_type = 0;
 uint8_t    ap_autopilot = 0;
 uint8_t    ap_base_mode = 0;


### PR DESCRIPTION
sysID and compID get saved only once if they are from a valid autopilot. We use them to check if further messages come from this autopilot and return early otherwise.
*This will break compatibility with PitLab flight stack because of their incorrect use of Mavlink (having autopilot type set to MAV_AUTOPILOT_INVALID).
**I didn't test this, because I couldn't compile with ArduinoIDE (some error with the log messages).